### PR TITLE
Add a `-v' flag to display binary version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ deps: $(DEP)
 	@env PATH="$(GOPATH)/bin:$(PATH)" $(DEP) ensure
 
 $(PKG): deps
-	@go build
+	@go build -ldflags "-X main.version=$(VERSION)"
 
 .PHONY: clean
 clean:

--- a/zlocker.go
+++ b/zlocker.go
@@ -6,20 +6,36 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/samuel/go-zookeeper/zk"
 )
 
-var sessionTimeout = flag.Int("t", 60, "Session timeout")
-var waitPeriod = flag.Int("w", 1, "Wait period before releasing lock")
-var zookeeperCluster = flag.String("z", "", "Address of zookeeper cluster")
-var lockName = flag.String("l", "", "Name of zookeeper lock to request")
+var (
+	sessionTimeout   = flag.Int("t", 60, "Session timeout")
+	waitPeriod       = flag.Int("w", 1, "Wait period before releasing lock")
+	zookeeperCluster = flag.String("z", "", "Address of zookeeper cluster")
+	lockName         = flag.String("l", "", "Name of zookeeper lock to request")
+	flagVersion      = flag.Bool("v", false, "Display version and exit")
+
+	version string
+)
 
 func main() {
-
 	flag.Parse()
+
+	if *flagVersion {
+		fmt.Printf("%s %s\nGo version: %s (%s)\n",
+			path.Base(os.Args[0]),
+			version,
+			runtime.Version(),
+			runtime.Compiler,
+		)
+		os.Exit(0)
+	}
 
 	logger := log.New(os.Stderr, "zlocker: ", 0)
 	if len(*zookeeperCluster) == 0 || len(*lockName) == 0 {


### PR DESCRIPTION
This change adds a new `-v` CLI flag to display the current binary
version and Go compiler version to produced it:

```
$ ./zlocker -v
zlocker v0.1.6-snapshot
Go version: go1.11 (gc)
```